### PR TITLE
Fixing an invalid usage of new

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ class Assets {
     };
 
     this.hooks = {
-      's3deploy:deploy': () => new Promise.resolve().then(this.deployS3.bind(this))
+      's3deploy:deploy': () => Promise.resolve().then(this.deployS3.bind(this))
     };
   }
 


### PR DESCRIPTION
`Promise.resolve` is not a constructor so it's not appropriate to use `new`.

Results in an error, if you do.