### PR TITLE
make compatible with serverless@1.25.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ class Assets {
               ContentType: type
             }, opt.headers || {});
 
-            this.provider.request('S3', 'putObject', details, this.options.stage, this.options.region);
+            this.provider.request('S3', 'putObject', details);
           });
         });
       });


### PR DESCRIPTION
Since serverless v1.25.x the awsProvider.request() signature has been changed.

https://github.com/serverless/serverless/commit/81c896bc127ed5a3d91277cafa7d8f53a45b3b27#diff-271ef5d492727880dcac1b94a86c878d

This fix will remove the following warning:

```
WARNING: Inappropriate call of provider.request()
```

This change is backwards compatible with serverless v1.24.x