### PR TITLE
Fix typo prefix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add to your serverless.yml:
               - '**/*.js'
               - '**/*.map'
        - bucket: my-other-bucket
-         prefix: /subdir'
+         prefix: subdir
          files:
           - source: ../email-templates/
             globs: '**/*.html'


### PR DESCRIPTION
If you include the slash string, an empty directory is created additionally.