### PR TITLE
Resolve Cloudformation Refs for dynamically named buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Add to your serverless.yml:
 You can specify any number of `target`s that you want. Each `target` has a
 `bucket` and a `prefix`.
 
+`bucket` is either the name of your S3 bucket or a reference to a
+CloudFormation resources created in the same serverless configuration file.
+See below for additional details.
+
 You can specify `source` relative to the current directory.
 
 Each `source` has its own list of `globs`, which can be either a single glob,
@@ -101,6 +105,33 @@ details.
             - source: html/
               headers:
                 CacheControl: max-age=31104000 # 1 year
+```
+
+## Resolving References
+
+A common use case is to create the S3 buckets in the `resources` section of
+your serverless configuration and then reference it in your S3 plugin
+settings:
+
+```
+  custom:
+    assets:
+      targets:
+        - bucket:
+            Ref: MyBucket
+          files:
+            - source: html/
+
+  resources:
+    # AWS CloudFormation Template
+    Resources:
+      MyBucket:
+        Type: AWS::S3::Bucket
+        Properties:
+          AccessControl: PublicRead
+          WebsiteConfiguration:
+            IndexDocument: index.html
+            ErrorDocument: index.html
 ```
 
 ## Auto-deploy

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.5.1",
     "glob-all": "^3.1.0",
     "mime-types": "^2.1.14"
   },


### PR DESCRIPTION
This pull requests allows you to use dynamic references instead of hardcoding bucket names.

A typical example would be:

```
# ...

plugins:
  - serverless-s3-deploy

custom:
  # Deploy S3 Assets
  assets:
    auto: true
    targets:
      - bucket:
          Ref: DistS3Bucket # <-------- this is now possible!
        acl: public-read
        files:
        #  - ...

resources:
  # AWS CloudFormation Template
  Resources:
    # S3 Buckets
    DistS3Bucket:
      Type: AWS::S3::Bucket
      Properties:
        AccessControl: PublicRead
        WebsiteConfiguration:
          IndexDocument: index.html
          ErrorDocument: index.html
```

The plugin is now able to resolve `Ref: DistS3Bucket` to the actual bucket name.
