### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ or a list of globs.
 Now you can upload all of these assets to your bucket by running:
 
 ```
-$ sls s3delpoy
+$ sls s3deploy
 ```
 
 If you have defined multiple buckets, you can limit your deployment to


### PR DESCRIPTION
This merge request changes `sls s3delpoy` to `sls s3deploy`