### PR TITLE
Add repository section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "Dan Rumney <dancrumb@gmail.com>"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/funkybob/serverless-s3-deploy.git"
+  },
   "dependencies": {
     "bluebird": "^3.5.1",
     "glob-all": "^3.1.0",


### PR DESCRIPTION
I was wondering why [NPMJS page](https://www.npmjs.com/package/serverless-s3-deploy)  was missing the link to github. I'd guess it because of missing repository entry.