### PR TITLE
Fix after-deploy hook not uploading

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ class Assets {
 
   afterDeploy() {
     if(this.config.auto) {
-      this.deployS3();
+      return this.deployS3();
     }
   }
 


### PR DESCRIPTION
Add a missing `return` so `deployS3()` is run after `sls deploy`.