### PR TITLE
Default ACL if not specified should be private

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ class Assets {
 
                 const details = Object.assign(
                   {
-                    ACL: assets.acl || 'public-read',
+                    ACL: assets.acl || 'private',
                     Body: body,
                     Bucket: bucket,
                     Key: key,


### PR DESCRIPTION
default to private for least privilege. See https://github.com/funkybob/serverless-s3-deploy/issues/42