### PR TITLE
Add type to cli options

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,11 +39,13 @@ class Assets {
         options: {
           verbose: {
             usage: 'Increase verbosity',
-            shortcut: 'v'
+            shortcut: 'v',
+            type: 'boolean'
           },
           bucket: {
             usage: 'Limit the deploy to a specific bucket',
-            shortcut: 'b'
+            shortcut: 'b',
+            type: 'string'
           }
         }
       }


### PR DESCRIPTION
CLI options without type definition has been deprecated.
https://www.serverless.com/framework/docs/deprecations#cli-options-extensions-type-requirement

This PR will add type definition for options.